### PR TITLE
Issue #5: also require auth on `POST /jobs/search`

### DIFF
--- a/src/jobs/controllers/jobs/jobs.controller.ts
+++ b/src/jobs/controllers/jobs/jobs.controller.ts
@@ -43,7 +43,6 @@ export class JobsController {
     description: 'Query supported by ElasticSearch',
     required: true,
   })
-  @Public()
   async queryJobs(@Body() query: any): Promise<Job[]> {
     try {
       return (await this.databaseService.queryJobs(query)) as Job[];


### PR DESCRIPTION
Issue #5: also require auth on `POST /jobs/search`